### PR TITLE
Allow gain=0 in "can add" command

### DIFF
--- a/src/openinverter_can_tool/cli.py
+++ b/src/openinverter_can_tool/cli.py
@@ -690,7 +690,7 @@ def cmd_can_list(
 @click.argument("param", required=True)
 @click.argument("position", required=True, type=click.IntRange(0, 64))
 @click.argument("length", required=True, type=click.IntRange(1, 64))
-@click.argument("gain", type=click.FloatRange(0.001, 16777.215), default=1.0)
+@click.argument("gain", type=click.FloatRange(0.0, 16777.215), default=1.0)
 @click.argument("offset", type=int, default=0)
 @pass_cli_settings
 @db_action


### PR DESCRIPTION
gain=0 is used when configuring CanWatchdog so this needs to be allowed.